### PR TITLE
Add font installation helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore downloaded fonts
+OWML_fonts_patch/Fonts/*.ttf
+OWML_fonts_patch/Mods/**/Fonts/*.ttf
+# Temporary download artifacts
+OWML_fonts_patch/Fonts/*.tmp
+OWML_fonts_patch/Mods/**/Fonts/*.tmp

--- a/OWML_fonts_patch/Fonts/README.md
+++ b/OWML_fonts_patch/Fonts/README.md
@@ -1,0 +1,3 @@
+# Fonts directory
+
+This directory is populated by the repository's `scripts/install_fonts.py` helper. The script downloads the open-source Noto Sans Regular font at install time so OWML and bundled mods can access Cyrillic glyphs without committing large binaries.

--- a/OWML_fonts_patch/Mods/PacificEngine.CheatsMod/Fonts/README.md
+++ b/OWML_fonts_patch/Mods/PacificEngine.CheatsMod/Fonts/README.md
@@ -1,0 +1,3 @@
+# Cheats Mod fonts
+
+Run `scripts/install_fonts.py` from the repository root to download `NotoSans-Regular.ttf` into this directory. The font is required for Cyrillic text in the mod UI but is fetched on demand to keep the repository PR-friendly.

--- a/OWML_fonts_patch/Mods/PacificEngine.CheatsMod/config.json
+++ b/OWML_fonts_patch/Mods/PacificEngine.CheatsMod/config.json
@@ -1,209 +1,717 @@
 {
   "enabled": true,
   "settings": {
-    "Vodyanoy znak": {
-      "no": "Disabled",
+    "Watermark": {
       "type": "toggle",
       "value": false,
-      "yes": "Enabled",
-      "title": "Vodyanoy znak"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Водяной знак"
     },
-    "Bessmertie igroka": {
-      "no": "Disabled",
+    "Player Invincible": {
       "type": "toggle",
       "value": false,
-      "yes": "Enabled",
-      "title": "Bessmertie igroka"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Бессмертие игрока"
     },
-    "Bessmertie korablya": {
-      "no": "Disabled",
+    "Ship Invincible": {
       "type": "toggle",
       "value": false,
-      "yes": "Enabled",
-      "title": "Bessmertie korablya"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Бессмертие корабля"
     },
-    "Beskonechnoe zdorove": {
-      "no": "Disabled",
+    "Unlimited Health": {
       "type": "toggle",
       "value": false,
-      "yes": "Enabled",
-      "title": "Beskonechnoe zdorove"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Бесконечное здоровье"
     },
-    "Beskonechnoe toplivo": {
-      "no": "Disabled",
+    "Unlimited Fuel": {
       "type": "toggle",
       "value": false,
-      "yes": "Enabled",
-      "title": "Beskonechnoe toplivo"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Бесконечное топливо"
     },
-    "Beskonechnyy kislorod": {
-      "no": "Disabled",
+    "Unlimited Oxygen": {
       "type": "toggle",
       "value": false,
-      "yes": "Enabled",
-      "title": "Beskonechnyy kislorod"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Бесконечный кислород"
     },
-    "Beskonechnyy uskoritel": {
-      "no": "Disabled",
+    "Unlimited Boost": {
       "type": "toggle",
       "value": false,
-      "yes": "Enabled",
-      "title": "Beskonechnyy uskoritel"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Бесконечный ускоритель"
     },
-    "II udilshchika": {
-      "no": "Disabled",
+    "Anglerfish AI": {
       "type": "toggle",
       "value": true,
-      "yes": "Enabled",
-      "title": "II udilshchika"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "ИИ удильщика"
     },
-    "II zhiteley": {
-      "no": "Disabled",
+    "Inhabitants AI": {
       "type": "toggle",
       "value": true,
-      "yes": "Enabled",
-      "title": "II zhiteley"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "ИИ жителей"
     },
-    "Tuman": {
-      "no": "Disabled",
+    "Fog": {
       "type": "toggle",
       "value": true,
-      "yes": "Enabled",
-      "title": "Tuman"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Туман"
     },
-    "Ogranichenie tyagi": {
-      "no": "Disabled",
+    "Thrust Limit": {
       "type": "toggle",
       "value": false,
-      "yes": "Enabled",
-      "title": "Ogranichenie tyagi"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Ограничение тяги"
     },
-    "Zapolnit toplivo i zdorove": "C,J",
-    "Pereklyuchit shlem": "C,H",
-    "Pereklyuchit bessmertie igroka": "C,I",
-    "Pereklyuchit bessmertie korablya": "C,Q",
-    "Pereklyuchit skafandr": "C,G",
-    "Pereklyuchit trenirovochnyy kostyum": "C,Digit1",
-    "Gravitatsiya igroka": "P,G",
-    "Gravitatsiya korablya": "S,G",
-    "Stolknoveniya igroka": "P,C",
-    "Stolknoveniya korablya": "S,C",
-    "Stolknoveniya igroka s zhidkostyu": "P,F",
-    "Stolknoveniya korablya s zhidkostyu": "S,F",
-    "Beskonechnyy uskoritel (vkl/vykl)": "C,T",
-    "Beskonechnoe toplivo (vkl/vykl)": "C,Y",
-    "Beskonechnyy kislorod (vkl/vykl)": "C,O",
-    "Beskonechnoe zdorove (vkl/vykl)": "C,U",
-    "Kody zapuska": "C,L",
-    "Koordinaty Oka": "C,E",
-    "Vse chastoty": "C,F",
-    "Slukhi": "C,R",
-    "Tuman (vkl/vykl)": "F,O,G",
-    "II udilshchika (vkl/vykl)": "V,I",
-    "II zhiteley (vkl/vykl)": "V,O",
-    "Vrazhdebnost zhiteley": "V,H",
-    "Taymer sverkhnovoy": "V,Digit0",
-    "Umenshit taymer sverkhnovoy": "V,Minus",
-    "Uvelichit taymer sverkhnovoy": "V,Equals",
-    "Kvantovaya luna: kollaps": "Q,Digit0",
-    "Kvantovaya luna: Peschanye bliznetsy": "Q,Digit1",
-    "Kvantovaya luna: Drevesnaya khizhina": "Q,Digit2",
-    "Kvantovaya luna: Khrupkaya polost": "Q,Digit3",
-    "Kvantovaya luna: Glubiny gigantov": "Q,Digit4",
-    "Kvantovaya luna: Temnaya ezhevika": "Q,Digit5",
-    "Kvantovaya luna: Oko": "Q,Digit6",
-    "Uvelichit uskorenie rantsa": "P,Equals",
-    "Umenshit uskorenie rantsa": "P,Minus",
-    "Umenshit uskorenie korablya": "O,Minus",
-    "Uvelichit uskorenie korablya": "O,Equals",
-    "Teleport k Solntsu": "T,Digit1",
-    "Teleport k Solnechnoy stantsii": "T,Digit2",
-    "Teleport k Peschanym bliznetsam": "T,Digit3",
-    "Teleport k Pepelnomu bliznetsu": "T,Digit4",
-    "Teleport k Proektu Pepelnogo bliznetsa": "T,Numpad8",
-    "Teleport k Drevesnoy khizhine": "T,Digit5",
-    "Teleport k sputniku SkyShutter": "T,Numpad1",
-    "Teleport k Atteroku": "T,Digit6",
-    "Teleport k Khrupkoy polosti": "T,Digit7",
-    "Teleport k Fonaryu polosti": "T,Digit8",
-    "Teleport k Glubinam gigantov": "T,Digit9",
-    "Teleport k pushke-zondu": "T,Numpad2",
-    "Teleport k modulyu slezheniya pushki-zonda": "T,NumpadPeriod",
-    "Teleport k Temnoy ezhevike": "T,Digit0",
-    "Teleport k Nezvanomu gostyu": "T,Numpad0",
-    "Teleport k Beloy dyre": "T,Numpad3",
-    "Teleport k stantsii Beloy dyry": "T,Numpad4",
-    "Teleport k Stranniku": "T,Numpad5",
-    "Teleport v Mir snov": "T,Numpad6",
-    "Teleport k Kvantovoy lune": "T,Numpad7",
-    "Teleport k korablyu": "T,Numpad9",
-    "Teleportirovat korabl k igroku": "T,NumpadDivide",
-    "Teleport k zondu": "T,NumpadMultiply",
-    "Teleport k zondy Nomai": "T,NumpadMinus",
-    "Teleport k Sudnu": "T,NumpadPlus",
-    "Teleport k kartograficheskomu sputniku": "T,M",
-    "Teleport k sputniku sponsorov": "T,B",
-    "Dat yadro varpa: Sudno": "G,T,Digit1",
-    "Dat yadro varpa: Slomannoe": "G,T,Digit2",
-    "Dat yadro varpa: Chernoe": "G,T,Digit3",
-    "Dat yadro varpa: Beloe": "G,T,Digit4",
-    "Ubrat yadro varpa": "G,T,Digit5",
-    "Dat fonar: obychnyy": "G,L,Digit1",
-    "Dat fonar: slomannyy": "G,L,Digit2",
-    "Dat fonar: pokolenie 1": "G,L,Digit3",
-    "Dat fonar: pokolenie 2": "G,L,Digit4",
-    "Dat fonar: pokolenie 3": "G,L,Digit5",
-    "Dat fakel videniy": "G,L,Digit6",
-    "Give Slide Story 1": "G,R,S,Digit1",
-    "Give Slide Story 2": "G,R,S,Digit2",
-    "Give Slide Story 3": "G,R,S,Digit3",
-    "Give Slide Story 4": "G,R,S,Digit4",
-    "Give Slide Story 5": "G,R,S,Digit5",
-    "Give Slide Burning": "G,R,S,Digit6",
-    "Give Slide Experiment": "G,R,S,Digit7",
-    "Give Slide DamageReport": "G,R,S,Digit8",
-    "Give Slide LanternSecret": "G,R,S,Digit9",
-    "Give Slide Prisoner": "G,R,S,Numpad0",
-    "Give Slide PrisonerFarewell": "G,R,S,Numpad1",
-    "Give Slide Tower": "G,R,S,Numpad2",
-    "Give Slide SignalJammer": "G,R,S,Numpad3",
-    "Give Slide Homeworld": "G,R,S,Numpad4",
-    "Give Slide SupernovaEscape": "G,R,S,Numpad5",
-    "Give Slide Path 1": "G,R,P,Digit1",
-    "Give Slide Path 2": "G,R,P,Digit2",
-    "Give Slide Path 3": "G,R,P,Digit3",
-    "Give Slide Seal 1": "G,R,P,Digit4",
-    "Give Slide Seal 2": "G,R,P,Digit5",
-    "Give Slide Seal 3": "G,R,P,Digit6",
-    "Give Slide Rule 1": "G,R,P,Digit7",
-    "Give Slide Rule 2": "G,R,P,Digit8",
-    "Give Slide Rule 3": "G,R,P,Digit9",
-    "Give Slide Rule 4": "G,R,P,Digit0",
-    "Give Identify Conversation Stone": "C,Digit2",
-    "Give Explain Conversation Stone": "C,Digit3",
-    "Give Eye Conversation Stone": "C,Digit4",
-    "Give Quantum Moon Conversation Stone": "C,Digit5",
-    "Give You Conversation Stone": "C,Digit6",
-    "Give Me Conversation Stone": "C,Digit7",
-    "Give Nomai Conversation Stone": "C,Digit8",
-    "Give Sun Station Projection Stone": "P,S,Digit1",
-    "Give Time Loop Projection Stone": "P,S,Digit2",
-    "Give Eye Locator Projection Stone": "P,S,Digit3",
-    "Give Mine Projection Stone": "P,S,Digit4",
-    "Give Observatory Projection Stone": "P,S,Digit5",
-    "Give Gravity Cannon Projection Stone": "P,S,Digit6",
-    "Give Quantum Fragment Projection Stone": "P,S,Digit7",
-    "Give Black Hole Forge Projection Stone": "P,S,Digit8",
-    "Give Construction Yard 1st Projection Stone": "P,S,Digit9",
-    "Give Construction Yard 2nd Projection Stone": "P,S,Digit0",
-    "Give Statue Projection Stone": "P,S,Numpad1",
-    "Give Tracking Module Projection Stone": "P,S,Numpad2",
-    "Give Launch Module Projection Stone": "P,S,Numpad3",
-    "Give Control Module Projection Stone": "P,S,Numpad4",
-    "Give Volcanic Projection Stone": "P,S,Numpad5",
-    "Give High Energy Lab Projection Stone": "P,S,Numpad6",
-    "Give North Pole Projection Stone": "P,S,Numpad7",
-    "Katapultirovat korabl": "LeftAlt,Digit1",
-    "Vzorvat korabl": "LeftAlt,Digit2"
+    "Fill Fuel and Health": {
+      "type": "text",
+      "value": "C,J",
+      "title": "Заполнить топливо и здоровье"
+    },
+    "Toggle Helmet": {
+      "type": "text",
+      "value": "C,H",
+      "title": "Переключить шлем"
+    },
+    "Toggle Player Invincibility": {
+      "type": "text",
+      "value": "C,I",
+      "title": "Переключить бессмертие игрока"
+    },
+    "Toggle Ship Invincibility": {
+      "type": "text",
+      "value": "C,Q",
+      "title": "Переключить бессмертие корабля"
+    },
+    "Toggle Spacesuit": {
+      "type": "text",
+      "value": "C,G",
+      "title": "Переключить скафандр"
+    },
+    "Toggle Training Suit": {
+      "type": "text",
+      "value": "C,Digit1",
+      "title": "Переключить тренировочный костюм"
+    },
+    "Toggle Player Gravity": {
+      "type": "text",
+      "value": "P,G",
+      "title": "Переключить гравитацию игрока"
+    },
+    "Toggle Ship Gravity": {
+      "type": "text",
+      "value": "S,G",
+      "title": "Переключить гравитацию корабля"
+    },
+    "Toggle Player Collision": {
+      "type": "text",
+      "value": "P,C",
+      "title": "Переключить столкновения игрока"
+    },
+    "Toggle Ship Collision": {
+      "type": "text",
+      "value": "S,C",
+      "title": "Переключить столкновения корабля"
+    },
+    "Toggle Player Fluid Collision": {
+      "type": "text",
+      "value": "P,F",
+      "title": "Переключить столкновения игрока с жидкостью"
+    },
+    "Toggle Ship Fluid Collision": {
+      "type": "text",
+      "value": "S,F",
+      "title": "Переключить столкновения корабля с жидкостью"
+    },
+    "Toggle Unlimited Boost": {
+      "type": "text",
+      "value": "C,T",
+      "title": "Переключить бесконечный ускоритель"
+    },
+    "Toggle Unlimited Fuel": {
+      "type": "text",
+      "value": "C,Y",
+      "title": "Переключить бесконечное топливо"
+    },
+    "Toggle Unlimited Oxygen": {
+      "type": "text",
+      "value": "C,O",
+      "title": "Переключить бесконечный кислород"
+    },
+    "Toggle Unlimited Health": {
+      "type": "text",
+      "value": "C,U",
+      "title": "Переключить бесконечное здоровье"
+    },
+    "Toggle Launch Codes": {
+      "type": "text",
+      "value": "C,L",
+      "title": "Переключить коды запуска"
+    },
+    "Toggle Eye Coordinates": {
+      "type": "text",
+      "value": "C,E",
+      "title": "Переключить координаты Ока"
+    },
+    "Toggle All Frequencies": {
+      "type": "text",
+      "value": "C,F",
+      "title": "Переключить все частоты"
+    },
+    "Toggle Rumors": {
+      "type": "text",
+      "value": "C,R",
+      "title": "Переключить слухи"
+    },
+    "Toggle Fog": {
+      "type": "text",
+      "value": "F,O,G",
+      "title": "Переключить туман"
+    },
+    "Toggle Anglerfish AI": {
+      "type": "text",
+      "value": "V,I",
+      "title": "Переключить ИИ удильщика"
+    },
+    "Toggle Inhabitants AI": {
+      "type": "text",
+      "value": "V,O",
+      "title": "Переключить ИИ жителей"
+    },
+    "Toggle Inhabitants Hostility": {
+      "type": "text",
+      "value": "V,H",
+      "title": "Переключить враждебность жителей"
+    },
+    "Toggle Supernova Timer": {
+      "type": "text",
+      "value": "V,Digit0",
+      "title": "Переключить таймер сверхновой"
+    },
+    "Decrease Supernova Timer": {
+      "type": "text",
+      "value": "V,Minus",
+      "title": "Уменьшить таймер сверхновой"
+    },
+    "Increase Supernova Timer": {
+      "type": "text",
+      "value": "V,Equals",
+      "title": "Увеличить таймер сверхновой"
+    },
+    "Quantum Moon Collapse": {
+      "type": "text",
+      "value": "Q,Digit0",
+      "title": "Квантовая луна: коллапс"
+    },
+    "Quantum Moon EmberTwin": {
+      "type": "text",
+      "value": "Q,Digit1",
+      "title": "Квантовая луна: Песчаные близнецы"
+    },
+    "Quantum Moon TimberHearth": {
+      "type": "text",
+      "value": "Q,Digit2",
+      "title": "Квантовая луна: Древесная хижина"
+    },
+    "Quantum Moon BrittleHollow": {
+      "type": "text",
+      "value": "Q,Digit3",
+      "title": "Квантовая луна: Хрупкая полость"
+    },
+    "Quantum Moon GiantsDeep": {
+      "type": "text",
+      "value": "Q,Digit4",
+      "title": "Квантовая луна: Глубины гигантов"
+    },
+    "Quantum Moon DarkBramble": {
+      "type": "text",
+      "value": "Q,Digit5",
+      "title": "Квантовая луна: Тёмная ежевика"
+    },
+    "Quantum Moon Eye": {
+      "type": "text",
+      "value": "Q,Digit6",
+      "title": "Квантовая луна: Око"
+    },
+    "Increase Jetpack Acceleration": {
+      "type": "text",
+      "value": "P,Equals",
+      "title": "Увеличить ускорение ранца"
+    },
+    "Decrease Jetpack Acceleration": {
+      "type": "text",
+      "value": "P,Minus",
+      "title": "Уменьшить ускорение ранца"
+    },
+    "Decrease Ship Acceleration": {
+      "type": "text",
+      "value": "O,Minus",
+      "title": "Уменьшить ускорение корабля"
+    },
+    "Increase Ship Acceleration": {
+      "type": "text",
+      "value": "O,Equals",
+      "title": "Увеличить ускорение корабля"
+    },
+    "Teleport To Sun": {
+      "type": "text",
+      "value": "T,Digit1",
+      "title": "Телепорт к Солнцу"
+    },
+    "Teleport To SunStation": {
+      "type": "text",
+      "value": "T,Digit2",
+      "title": "Телепорт к Солнечной станции"
+    },
+    "Teleport To EmberTwin": {
+      "type": "text",
+      "value": "T,Digit3",
+      "title": "Телепорт к Песчаным близнецам"
+    },
+    "Teleport To AshTwin": {
+      "type": "text",
+      "value": "T,Digit4",
+      "title": "Телепорт к Пепельному близнецу"
+    },
+    "Teleport To AshTwinProject": {
+      "type": "text",
+      "value": "T,Numpad8",
+      "title": "Телепорт к Проекту Пепельного близнеца"
+    },
+    "Teleport To TimberHearth": {
+      "type": "text",
+      "value": "T,Digit5",
+      "title": "Телепорт к Древесной хижине"
+    },
+    "Teleport To SkyShutterSatellite": {
+      "type": "text",
+      "value": "T,Numpad1",
+      "title": "Телепорт к спутнику «SkyShutter»"
+    },
+    "Teleport To Attlerock": {
+      "type": "text",
+      "value": "T,Digit6",
+      "title": "Телепорт к Аттероку"
+    },
+    "Teleport To BrittleHollow": {
+      "type": "text",
+      "value": "T,Digit7",
+      "title": "Телепорт к Хрупкой полости"
+    },
+    "Teleport To HollowsLantern": {
+      "type": "text",
+      "value": "T,Digit8",
+      "title": "Телепорт к Фонарю полости"
+    },
+    "Teleport To GiantsDeep": {
+      "type": "text",
+      "value": "T,Digit9",
+      "title": "Телепорт к Глубинам гигантов"
+    },
+    "Teleport To ProbeCannon": {
+      "type": "text",
+      "value": "T,Numpad2",
+      "title": "Телепорт к пушке-зонду"
+    },
+    "Teleport To ProbeCannonTrackingModule": {
+      "type": "text",
+      "value": "T,NumpadPeriod",
+      "title": "Телепорт к модулю слежения пушки-зонда"
+    },
+    "Teleport To DarkBramble": {
+      "type": "text",
+      "value": "T,Digit0",
+      "title": "Телепорт к Тёмной ежевике"
+    },
+    "Teleport To Interloper": {
+      "type": "text",
+      "value": "T,Numpad0",
+      "title": "Телепорт к Незваному гостю"
+    },
+    "Teleport To WhiteHole": {
+      "type": "text",
+      "value": "T,Numpad3",
+      "title": "Телепорт к Белой дыре"
+    },
+    "Teleport To WhiteHoleStation": {
+      "type": "text",
+      "value": "T,Numpad4",
+      "title": "Телепорт к станции Белой дыры"
+    },
+    "Teleport To Stranger": {
+      "type": "text",
+      "value": "T,Numpad5",
+      "title": "Телепорт к Страннику"
+    },
+    "Teleport To DreamWorld": {
+      "type": "text",
+      "value": "T,Numpad6",
+      "title": "Телепорт в Мир снов"
+    },
+    "Teleport To QuantumMoon": {
+      "type": "text",
+      "value": "T,Numpad7",
+      "title": "Телепорт к Квантовой луне"
+    },
+    "Teleport To Ship": {
+      "type": "text",
+      "value": "T,Numpad9",
+      "title": "Телепорт к кораблю"
+    },
+    "Teleport Ship To Player": {
+      "type": "text",
+      "value": "T,NumpadDivide",
+      "title": "Телепортировать корабль к игроку"
+    },
+    "Teleport To Probe": {
+      "type": "text",
+      "value": "T,NumpadMultiply",
+      "title": "Телепорт к зонду"
+    },
+    "Teleport To Nomai Probe": {
+      "type": "text",
+      "value": "T,NumpadMinus",
+      "title": "Телепорт к зонду Номаи"
+    },
+    "Teleport To Vessel": {
+      "type": "text",
+      "value": "T,NumpadPlus",
+      "title": "Телепорт к Судну"
+    },
+    "Teleport To Mapping Satellite": {
+      "type": "text",
+      "value": "T,M",
+      "title": "Телепорт к картографическому спутнику"
+    },
+    "Teleport To Backer Satellite": {
+      "type": "text",
+      "value": "T,B",
+      "title": "Телепорт к спутнику спонсоров"
+    },
+    "Give Warp Core Vessel": {
+      "type": "text",
+      "value": "G,T,Digit1",
+      "title": "Выдать варп-ядро: Судно"
+    },
+    "Give Warp Core Broken": {
+      "type": "text",
+      "value": "G,T,Digit2",
+      "title": "Выдать варп-ядро: сломанное"
+    },
+    "Give Warp Core Black": {
+      "type": "text",
+      "value": "G,T,Digit3",
+      "title": "Выдать варп-ядро: чёрное"
+    },
+    "Give Warp Core White": {
+      "type": "text",
+      "value": "G,T,Digit4",
+      "title": "Выдать варп-ядро: белое"
+    },
+    "Give Warp Core None": {
+      "type": "text",
+      "value": "G,T,Digit5",
+      "title": "Убрать варп-ядро"
+    },
+    "Give Lantern Basic": {
+      "type": "text",
+      "value": "G,L,Digit1",
+      "title": "Выдать фонарь: обычный"
+    },
+    "Give Lantern Broken": {
+      "type": "text",
+      "value": "G,L,Digit2",
+      "title": "Выдать фонарь: сломанный"
+    },
+    "Give Lantern Gen1": {
+      "type": "text",
+      "value": "G,L,Digit3",
+      "title": "Выдать фонарь: поколение 1"
+    },
+    "Give Lantern Gen2": {
+      "type": "text",
+      "value": "G,L,Digit4",
+      "title": "Выдать фонарь: поколение 2"
+    },
+    "Give Lantern Gen3": {
+      "type": "text",
+      "value": "G,L,Digit5",
+      "title": "Выдать фонарь: поколение 3"
+    },
+    "Give Vision Torch": {
+      "type": "text",
+      "value": "G,L,Digit6",
+      "title": "Выдать факел видений"
+    },
+    "Give Slide Story 1": {
+      "type": "text",
+      "value": "G,R,S,Digit1",
+      "title": "Выдать сюжетный слайд 1"
+    },
+    "Give Slide Story 2": {
+      "type": "text",
+      "value": "G,R,S,Digit2",
+      "title": "Выдать сюжетный слайд 2"
+    },
+    "Give Slide Story 3": {
+      "type": "text",
+      "value": "G,R,S,Digit3",
+      "title": "Выдать сюжетный слайд 3"
+    },
+    "Give Slide Story 4": {
+      "type": "text",
+      "value": "G,R,S,Digit4",
+      "title": "Выдать сюжетный слайд 4"
+    },
+    "Give Slide Story 5": {
+      "type": "text",
+      "value": "G,R,S,Digit5",
+      "title": "Выдать сюжетный слайд 5"
+    },
+    "Give Slide Burning": {
+      "type": "text",
+      "value": "G,R,S,Digit6",
+      "title": "Выдать слайд «Пламя»"
+    },
+    "Give Slide Experiment": {
+      "type": "text",
+      "value": "G,R,S,Digit7",
+      "title": "Выдать слайд «Эксперимент»"
+    },
+    "Give Slide DamageReport": {
+      "type": "text",
+      "value": "G,R,S,Digit8",
+      "title": "Выдать слайд «Отчёт о повреждениях»"
+    },
+    "Give Slide LanternSecret": {
+      "type": "text",
+      "value": "G,R,S,Digit9",
+      "title": "Выдать слайд «Тайна фонаря»"
+    },
+    "Give Slide Prisoner": {
+      "type": "text",
+      "value": "G,R,S,Numpad0",
+      "title": "Выдать слайд «Заключённый»"
+    },
+    "Give Slide PrisonerFarewell": {
+      "type": "text",
+      "value": "G,R,S,Numpad1",
+      "title": "Выдать слайд «Прощание заключённого»"
+    },
+    "Give Slide Tower": {
+      "type": "text",
+      "value": "G,R,S,Numpad2",
+      "title": "Выдать слайд «Башня»"
+    },
+    "Give Slide SignalJammer": {
+      "type": "text",
+      "value": "G,R,S,Numpad3",
+      "title": "Выдать слайд «Глушитель сигнала»"
+    },
+    "Give Slide Homeworld": {
+      "type": "text",
+      "value": "G,R,S,Numpad4",
+      "title": "Выдать слайд «Родной мир»"
+    },
+    "Give Slide SupernovaEscape": {
+      "type": "text",
+      "value": "G,R,S,Numpad5",
+      "title": "Выдать слайд «Побег от сверхновой»"
+    },
+    "Give Slide Path 1": {
+      "type": "text",
+      "value": "G,R,P,Digit1",
+      "title": "Выдать слайд «Путь 1»"
+    },
+    "Give Slide Path 2": {
+      "type": "text",
+      "value": "G,R,P,Digit2",
+      "title": "Выдать слайд «Путь 2»"
+    },
+    "Give Slide Path 3": {
+      "type": "text",
+      "value": "G,R,P,Digit3",
+      "title": "Выдать слайд «Путь 3»"
+    },
+    "Give Slide Seal 1": {
+      "type": "text",
+      "value": "G,R,P,Digit4",
+      "title": "Выдать слайд «Печать 1»"
+    },
+    "Give Slide Seal 2": {
+      "type": "text",
+      "value": "G,R,P,Digit5",
+      "title": "Выдать слайд «Печать 2»"
+    },
+    "Give Slide Seal 3": {
+      "type": "text",
+      "value": "G,R,P,Digit6",
+      "title": "Выдать слайд «Печать 3»"
+    },
+    "Give Slide Rule 1": {
+      "type": "text",
+      "value": "G,R,P,Digit7",
+      "title": "Выдать слайд «Правило 1»"
+    },
+    "Give Slide Rule 2": {
+      "type": "text",
+      "value": "G,R,P,Digit8",
+      "title": "Выдать слайд «Правило 2»"
+    },
+    "Give Slide Rule 3": {
+      "type": "text",
+      "value": "G,R,P,Digit9",
+      "title": "Выдать слайд «Правило 3»"
+    },
+    "Give Slide Rule 4": {
+      "type": "text",
+      "value": "G,R,P,Digit0",
+      "title": "Выдать слайд «Правило 4»"
+    },
+    "Give Identify Conversation Stone": {
+      "type": "text",
+      "value": "C,Digit2",
+      "title": "Выдать камень беседы «Опознать»"
+    },
+    "Give Explain Conversation Stone": {
+      "type": "text",
+      "value": "C,Digit3",
+      "title": "Выдать камень беседы «Объяснить»"
+    },
+    "Give Eye Conversation Stone": {
+      "type": "text",
+      "value": "C,Digit4",
+      "title": "Выдать камень беседы «Око»"
+    },
+    "Give Quantum Moon Conversation Stone": {
+      "type": "text",
+      "value": "C,Digit5",
+      "title": "Выдать камень беседы «Квантовая луна»"
+    },
+    "Give You Conversation Stone": {
+      "type": "text",
+      "value": "C,Digit6",
+      "title": "Выдать камень беседы «Ты»"
+    },
+    "Give Me Conversation Stone": {
+      "type": "text",
+      "value": "C,Digit7",
+      "title": "Выдать камень беседы «Я»"
+    },
+    "Give Nomai Conversation Stone": {
+      "type": "text",
+      "value": "C,Digit8",
+      "title": "Выдать камень беседы «Номаи»"
+    },
+    "Give Sun Station Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit1",
+      "title": "Выдать проекционный камень «Солнечная станция»"
+    },
+    "Give Time Loop Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit2",
+      "title": "Выдать проекционный камень «Петля времени»"
+    },
+    "Give Eye Locator Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit3",
+      "title": "Выдать проекционный камень «Локатор Ока»"
+    },
+    "Give Mine Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit4",
+      "title": "Выдать проекционный камень «Шахта»"
+    },
+    "Give Observatory Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit5",
+      "title": "Выдать проекционный камень «Обсерватория»"
+    },
+    "Give Gravity Cannon Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit6",
+      "title": "Выдать проекционный камень «Гравитационная пушка»"
+    },
+    "Give Quantum Fragment Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit7",
+      "title": "Выдать проекционный камень «Квантовый фрагмент»"
+    },
+    "Give Black Hole Forge Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit8",
+      "title": "Выдать проекционный камень «Кузница чёрной дыры»"
+    },
+    "Give Construction Yard 1st Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit9",
+      "title": "Выдать проекционный камень «Строительная площадка 1»"
+    },
+    "Give Construction Yard 2nd Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit0",
+      "title": "Выдать проекционный камень «Строительная площадка 2»"
+    },
+    "Give Statue Projection Stone": {
+      "type": "text",
+      "value": "P,S,Numpad1",
+      "title": "Выдать проекционный камень «Статуя»"
+    },
+    "Give Tracking Module Projection Stone": {
+      "type": "text",
+      "value": "P,S,Numpad2",
+      "title": "Выдать проекционный камень «Отслеживающий модуль»"
+    },
+    "Give Launch Module Projection Stone": {
+      "type": "text",
+      "value": "P,S,Numpad3",
+      "title": "Выдать проекционный камень «Пусковой модуль»"
+    },
+    "Give Control Module Projection Stone": {
+      "type": "text",
+      "value": "P,S,Numpad4",
+      "title": "Выдать проекционный камень «Управляющий модуль»"
+    },
+    "Give Volcanic Projection Stone": {
+      "type": "text",
+      "value": "P,S,Numpad5",
+      "title": "Выдать проекционный камень «Вулканический»"
+    },
+    "Give High Energy Lab Projection Stone": {
+      "type": "text",
+      "value": "P,S,Numpad6",
+      "title": "Выдать проекционный камень «Лаборатория высокой энергии»"
+    },
+    "Give North Pole Projection Stone": {
+      "type": "text",
+      "value": "P,S,Numpad7",
+      "title": "Выдать проекционный камень «Северный полюс»"
+    },
+    "Eject Ship": {
+      "type": "text",
+      "value": "LeftAlt,Digit1",
+      "title": "Катапультировать корабль"
+    },
+    "Explode Ship": {
+      "type": "text",
+      "value": "LeftAlt,Digit2",
+      "title": "Взорвать корабль"
+    }
   }
 }

--- a/OWML_fonts_patch/Mods/PacificEngine.CheatsMod/default-config.json
+++ b/OWML_fonts_patch/Mods/PacificEngine.CheatsMod/default-config.json
@@ -4,216 +4,714 @@
     "Watermark": {
       "type": "toggle",
       "value": true,
-      "yes": "Enabled",
-      "no": "Disabled",
-      "title": "Watermark"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Водяной знак"
     },
     "Player Invincible": {
       "type": "toggle",
       "value": true,
-      "yes": "Enabled",
-      "no": "Disabled",
-      "title": "Player Invincible"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Бессмертие игрока"
     },
     "Ship Invincible": {
       "type": "toggle",
       "value": true,
-      "yes": "Enabled",
-      "no": "Disabled",
-      "title": "Ship Invincible"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Бессмертие корабля"
     },
     "Unlimited Health": {
       "type": "toggle",
       "value": true,
-      "yes": "Enabled",
-      "no": "Disabled",
-      "title": "Unlimited Health"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Бесконечное здоровье"
     },
     "Unlimited Fuel": {
       "type": "toggle",
       "value": true,
-      "yes": "Enabled",
-      "no": "Disabled",
-      "title": "Unlimited Fuel"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Бесконечное топливо"
     },
     "Unlimited Oxygen": {
       "type": "toggle",
       "value": true,
-      "yes": "Enabled",
-      "no": "Disabled",
-      "title": "Unlimited Oxygen"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Бесконечный кислород"
     },
     "Unlimited Boost": {
       "type": "toggle",
       "value": true,
-      "yes": "Enabled",
-      "no": "Disabled",
-      "title": "Unlimited Boost"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Бесконечный ускоритель"
     },
     "Anglerfish AI": {
       "type": "toggle",
       "value": true,
-      "yes": "Enabled",
-      "no": "Disabled",
-      "title": "Anglerfish AI"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "ИИ удильщика"
     },
     "Inhabitants AI": {
       "type": "toggle",
       "value": true,
-      "yes": "Enabled",
-      "no": "Disabled",
-      "title": "Inhabitants AI"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "ИИ жителей"
     },
     "Fog": {
       "type": "toggle",
       "value": true,
-      "yes": "Enabled",
-      "no": "Disabled",
-      "title": "Fog"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Туман"
     },
     "Thrust Limit": {
       "type": "toggle",
       "value": false,
-      "yes": "Enabled",
-      "no": "Disabled",
-      "title": "Thrust Limit"
+      "yes": "Включено",
+      "no": "Отключено",
+      "title": "Ограничение тяги"
     },
-
-    "Fill Fuel and Health": "C,J",
-    "Toggle Helmet": "C,H",
-    "Toggle Player Invincibility": "C,I",
-    "Toggle Ship Invincibility": "C,Q",
-    "Toggle Spacesuit": "C,G",
-    "Toggle Training Suit": "C,Digit1",
-    "Toggle Player Gravity": "P,G",
-    "Toggle Ship Gravity": "S,G",
-    "Toggle Player Collision": "P,C",
-    "Toggle Ship Collision": "S,C",
-    "Toggle Player Fluid Collision": "P,F",
-    "Toggle Ship Fluid Collision": "S,F",
-    "Toggle Unlimited Boost": "C,T",
-    "Toggle Unlimited Fuel": "C,Y",
-    "Toggle Unlimited Oxygen": "C,O",
-    "Toggle Unlimited Health": "C,U",
-
-    "Toggle Launch Codes": "C,L",
-    "Toggle Eye Coordinates": "C,E",
-    "Toggle All Frequencies": "C,F",
-    "Toggle Rumors": "C,R",
-
-    "Toggle Fog": "F,O,G",
-    "Toggle Anglerfish AI": "V,I",
-    "Toggle Inhabitants AI": "V,O",
-    "Toggle Inhabitants Hostility": "V,H",
-    "Toggle Supernova Timer": "V,Digit0",
-    "Decrease Supernova Timer": "V,Minus",
-    "Increase Supernova Timer": "V,Equals",
-
-    "Quantum Moon Collapse": "Q,Digit0",
-    "Quantum Moon EmberTwin": "Q,Digit1",
-    "Quantum Moon TimberHearth": "Q,Digit2",
-    "Quantum Moon BrittleHollow": "Q,Digit3",
-    "Quantum Moon GiantsDeep": "Q,Digit4",
-    "Quantum Moon DarkBramble": "Q,Digit5",
-    "Quantum Moon Eye": "Q,Digit6",
-
-    "Increase Jetpack Acceleration": "P,Equals",
-    "Decrease Jetpack Acceleration": "P,Minus",
-    "Decrease Ship Acceleration": "O,Minus",
-    "Increase Ship Acceleration": "O,Equals",
-
-    "Teleport To Sun": "T,Digit1",
-    "Teleport To SunStation": "T,Digit2",
-    "Teleport To EmberTwin": "T,Digit3",
-    "Teleport To AshTwin": "T,Digit4",
-    "Teleport To AshTwinProject": "T,Numpad8",
-    "Teleport To TimberHearth": "T,Digit5",
-    "Teleport To SkyShutterSatellite": "T,Numpad1",
-    "Teleport To Attlerock": "T,Digit6",
-    "Teleport To BrittleHollow": "T,Digit7",
-    "Teleport To HollowsLantern": "T,Digit8",
-    "Teleport To GiantsDeep": "T,Digit9",
-    "Teleport To ProbeCannon": "T,Numpad2",
-    "Teleport To ProbeCannonTrackingModule": "T,NumpadPeriod",
-    "Teleport To DarkBramble": "T,Digit0",
-    "Teleport To Interloper": "T,Numpad0",
-    "Teleport To WhiteHole": "T,Numpad3",
-    "Teleport To WhiteHoleStation": "T,Numpad4",
-    "Teleport To Stranger": "T,Numpad5",
-    "Teleport To DreamWorld": "T,Numpad6",
-    "Teleport To QuantumMoon": "T,Numpad7",
-    "Teleport To Ship": "T,Numpad9",
-    "Teleport Ship To Player": "T,NumpadDivide",
-    "Teleport To Probe": "T,NumpadMultiply",
-    "Teleport To Nomai Probe": "T,NumpadMinus",
-    "Teleport To Vessel": "T,NumpadPlus",
-    "Teleport To Mapping Satellite": "T,M",
-    "Teleport To Backer Satellite": "T,B",
-
-    "Give Warp Core Vessel": "G,T,Digit1",
-    "Give Warp Core Broken": "G,T,Digit2",
-    "Give Warp Core Black": "G,T,Digit3",
-    "Give Warp Core White": "G,T,Digit4",
-    "Give Warp Core None": "G,T,Digit5",
-    "Give Lantern Basic": "G,L,Digit1",
-    "Give Lantern Broken": "G,L,Digit2",
-    "Give Lantern Gen1": "G,L,Digit3",
-    "Give Lantern Gen2": "G,L,Digit4",
-    "Give Lantern Gen3": "G,L,Digit5",
-    "Give Vision Torch": "G,L,Digit6",
-    "Give Slide Story 1": "G,R,S,Digit1",
-    "Give Slide Story 2": "G,R,S,Digit2",
-    "Give Slide Story 3": "G,R,S,Digit3",
-    "Give Slide Story 4": "G,R,S,Digit4",
-    "Give Slide Story 5": "G,R,S,Digit5",
-    "Give Slide Burning": "G,R,S,Digit6",
-    "Give Slide Experiment": "G,R,S,Digit7",
-    "Give Slide DamageReport": "G,R,S,Digit8",
-    "Give Slide LanternSecret": "G,R,S,Digit9",
-    "Give Slide Prisoner": "G,R,S,Numpad0",
-    "Give Slide PrisonerFarewell": "G,R,S,Numpad1",
-    "Give Slide Tower": "G,R,S,Numpad2",
-    "Give Slide SignalJammer": "G,R,S,Numpad3",
-    "Give Slide Homeworld": "G,R,S,Numpad4",
-    "Give Slide SupernovaEscape": "G,R,S,Numpad5",
-    "Give Slide Path 1": "G,R,P,Digit1",
-    "Give Slide Path 2": "G,R,P,Digit2",
-    "Give Slide Path 3": "G,R,P,Digit3",
-    "Give Slide Seal 1": "G,R,P,Digit4",
-    "Give Slide Seal 2": "G,R,P,Digit5",
-    "Give Slide Seal 3": "G,R,P,Digit6",
-    "Give Slide Rule 1": "G,R,P,Digit7",
-    "Give Slide Rule 2": "G,R,P,Digit8",
-    "Give Slide Rule 3": "G,R,P,Digit9",
-    "Give Slide Rule 4": "G,R,P,Digit0",
-
-    "Give Identify Conversation Stone": "C,Digit2",
-    "Give Explain Conversation Stone": "C,Digit3",
-    "Give Eye Conversation Stone": "C,Digit4",
-    "Give Quantum Moon Conversation Stone": "C,Digit5",
-    "Give You Conversation Stone": "C,Digit6",
-    "Give Me Conversation Stone": "C,Digit7",
-    "Give Nomai Conversation Stone": "C,Digit8",
-
-    "Give Sun Station Projection Stone": "P,S,Digit1",
-    "Give Time Loop Projection Stone": "P,S,Digit2",
-    "Give Eye Locator Projection Stone": "P,S,Digit3",
-    "Give Mine Projection Stone": "P,S,Digit4",
-    "Give Observatory Projection Stone": "P,S,Digit5",
-    "Give Gravity Cannon Projection Stone": "P,S,Digit6",
-    "Give Quantum Fragment Projection Stone": "P,S,Digit7",
-    "Give Black Hole Forge Projection Stone": "P,S,Digit8",
-    "Give Construction Yard 1st Projection Stone": "P,S,Digit9",
-    "Give Construction Yard 2nd Projection Stone": "P,S,Digit0",
-    "Give Statue Projection Stone": "P,S,Numpad1",
-    "Give Tracking Module Projection Stone": "P,S,Numpad2",
-    "Give Launch Module Projection Stone": "P,S,Numpad3",
-    "Give Control Module Projection Stone": "P,S,Numpad4",
-    "Give Volcanic Projection Stone": "P,S,Numpad5",
-    "Give High Energy Lab Projection Stone": "P,S,Numpad6",
-    "Give North Pole Projection Stone": "P,S,Numpad7",
-
-    "Eject Ship": "LeftAlt,Digit1",
-    "Explode Ship": "LeftAlt,Digit2"
+    "Fill Fuel and Health": {
+      "type": "text",
+      "value": "C,J",
+      "title": "Заполнить топливо и здоровье"
+    },
+    "Toggle Helmet": {
+      "type": "text",
+      "value": "C,H",
+      "title": "Переключить шлем"
+    },
+    "Toggle Player Invincibility": {
+      "type": "text",
+      "value": "C,I",
+      "title": "Переключить бессмертие игрока"
+    },
+    "Toggle Ship Invincibility": {
+      "type": "text",
+      "value": "C,Q",
+      "title": "Переключить бессмертие корабля"
+    },
+    "Toggle Spacesuit": {
+      "type": "text",
+      "value": "C,G",
+      "title": "Переключить скафандр"
+    },
+    "Toggle Training Suit": {
+      "type": "text",
+      "value": "C,Digit1",
+      "title": "Переключить тренировочный костюм"
+    },
+    "Toggle Player Gravity": {
+      "type": "text",
+      "value": "P,G",
+      "title": "Переключить гравитацию игрока"
+    },
+    "Toggle Ship Gravity": {
+      "type": "text",
+      "value": "S,G",
+      "title": "Переключить гравитацию корабля"
+    },
+    "Toggle Player Collision": {
+      "type": "text",
+      "value": "P,C",
+      "title": "Переключить столкновения игрока"
+    },
+    "Toggle Ship Collision": {
+      "type": "text",
+      "value": "S,C",
+      "title": "Переключить столкновения корабля"
+    },
+    "Toggle Player Fluid Collision": {
+      "type": "text",
+      "value": "P,F",
+      "title": "Переключить столкновения игрока с жидкостью"
+    },
+    "Toggle Ship Fluid Collision": {
+      "type": "text",
+      "value": "S,F",
+      "title": "Переключить столкновения корабля с жидкостью"
+    },
+    "Toggle Unlimited Boost": {
+      "type": "text",
+      "value": "C,T",
+      "title": "Переключить бесконечный ускоритель"
+    },
+    "Toggle Unlimited Fuel": {
+      "type": "text",
+      "value": "C,Y",
+      "title": "Переключить бесконечное топливо"
+    },
+    "Toggle Unlimited Oxygen": {
+      "type": "text",
+      "value": "C,O",
+      "title": "Переключить бесконечный кислород"
+    },
+    "Toggle Unlimited Health": {
+      "type": "text",
+      "value": "C,U",
+      "title": "Переключить бесконечное здоровье"
+    },
+    "Toggle Launch Codes": {
+      "type": "text",
+      "value": "C,L",
+      "title": "Переключить коды запуска"
+    },
+    "Toggle Eye Coordinates": {
+      "type": "text",
+      "value": "C,E",
+      "title": "Переключить координаты Ока"
+    },
+    "Toggle All Frequencies": {
+      "type": "text",
+      "value": "C,F",
+      "title": "Переключить все частоты"
+    },
+    "Toggle Rumors": {
+      "type": "text",
+      "value": "C,R",
+      "title": "Переключить слухи"
+    },
+    "Toggle Fog": {
+      "type": "text",
+      "value": "F,O,G",
+      "title": "Переключить туман"
+    },
+    "Toggle Anglerfish AI": {
+      "type": "text",
+      "value": "V,I",
+      "title": "Переключить ИИ удильщика"
+    },
+    "Toggle Inhabitants AI": {
+      "type": "text",
+      "value": "V,O",
+      "title": "Переключить ИИ жителей"
+    },
+    "Toggle Inhabitants Hostility": {
+      "type": "text",
+      "value": "V,H",
+      "title": "Переключить враждебность жителей"
+    },
+    "Toggle Supernova Timer": {
+      "type": "text",
+      "value": "V,Digit0",
+      "title": "Переключить таймер сверхновой"
+    },
+    "Decrease Supernova Timer": {
+      "type": "text",
+      "value": "V,Minus",
+      "title": "Уменьшить таймер сверхновой"
+    },
+    "Increase Supernova Timer": {
+      "type": "text",
+      "value": "V,Equals",
+      "title": "Увеличить таймер сверхновой"
+    },
+    "Quantum Moon Collapse": {
+      "type": "text",
+      "value": "Q,Digit0",
+      "title": "Квантовая луна: коллапс"
+    },
+    "Quantum Moon EmberTwin": {
+      "type": "text",
+      "value": "Q,Digit1",
+      "title": "Квантовая луна: Песчаные близнецы"
+    },
+    "Quantum Moon TimberHearth": {
+      "type": "text",
+      "value": "Q,Digit2",
+      "title": "Квантовая луна: Древесная хижина"
+    },
+    "Quantum Moon BrittleHollow": {
+      "type": "text",
+      "value": "Q,Digit3",
+      "title": "Квантовая луна: Хрупкая полость"
+    },
+    "Quantum Moon GiantsDeep": {
+      "type": "text",
+      "value": "Q,Digit4",
+      "title": "Квантовая луна: Глубины гигантов"
+    },
+    "Quantum Moon DarkBramble": {
+      "type": "text",
+      "value": "Q,Digit5",
+      "title": "Квантовая луна: Тёмная ежевика"
+    },
+    "Quantum Moon Eye": {
+      "type": "text",
+      "value": "Q,Digit6",
+      "title": "Квантовая луна: Око"
+    },
+    "Increase Jetpack Acceleration": {
+      "type": "text",
+      "value": "P,Equals",
+      "title": "Увеличить ускорение ранца"
+    },
+    "Decrease Jetpack Acceleration": {
+      "type": "text",
+      "value": "P,Minus",
+      "title": "Уменьшить ускорение ранца"
+    },
+    "Decrease Ship Acceleration": {
+      "type": "text",
+      "value": "O,Minus",
+      "title": "Уменьшить ускорение корабля"
+    },
+    "Increase Ship Acceleration": {
+      "type": "text",
+      "value": "O,Equals",
+      "title": "Увеличить ускорение корабля"
+    },
+    "Teleport To Sun": {
+      "type": "text",
+      "value": "T,Digit1",
+      "title": "Телепорт к Солнцу"
+    },
+    "Teleport To SunStation": {
+      "type": "text",
+      "value": "T,Digit2",
+      "title": "Телепорт к Солнечной станции"
+    },
+    "Teleport To EmberTwin": {
+      "type": "text",
+      "value": "T,Digit3",
+      "title": "Телепорт к Песчаным близнецам"
+    },
+    "Teleport To AshTwin": {
+      "type": "text",
+      "value": "T,Digit4",
+      "title": "Телепорт к Пепельному близнецу"
+    },
+    "Teleport To AshTwinProject": {
+      "type": "text",
+      "value": "T,Numpad8",
+      "title": "Телепорт к Проекту Пепельного близнеца"
+    },
+    "Teleport To TimberHearth": {
+      "type": "text",
+      "value": "T,Digit5",
+      "title": "Телепорт к Древесной хижине"
+    },
+    "Teleport To SkyShutterSatellite": {
+      "type": "text",
+      "value": "T,Numpad1",
+      "title": "Телепорт к спутнику «SkyShutter»"
+    },
+    "Teleport To Attlerock": {
+      "type": "text",
+      "value": "T,Digit6",
+      "title": "Телепорт к Аттероку"
+    },
+    "Teleport To BrittleHollow": {
+      "type": "text",
+      "value": "T,Digit7",
+      "title": "Телепорт к Хрупкой полости"
+    },
+    "Teleport To HollowsLantern": {
+      "type": "text",
+      "value": "T,Digit8",
+      "title": "Телепорт к Фонарю полости"
+    },
+    "Teleport To GiantsDeep": {
+      "type": "text",
+      "value": "T,Digit9",
+      "title": "Телепорт к Глубинам гигантов"
+    },
+    "Teleport To ProbeCannon": {
+      "type": "text",
+      "value": "T,Numpad2",
+      "title": "Телепорт к пушке-зонду"
+    },
+    "Teleport To ProbeCannonTrackingModule": {
+      "type": "text",
+      "value": "T,NumpadPeriod",
+      "title": "Телепорт к модулю слежения пушки-зонда"
+    },
+    "Teleport To DarkBramble": {
+      "type": "text",
+      "value": "T,Digit0",
+      "title": "Телепорт к Тёмной ежевике"
+    },
+    "Teleport To Interloper": {
+      "type": "text",
+      "value": "T,Numpad0",
+      "title": "Телепорт к Незваному гостю"
+    },
+    "Teleport To WhiteHole": {
+      "type": "text",
+      "value": "T,Numpad3",
+      "title": "Телепорт к Белой дыре"
+    },
+    "Teleport To WhiteHoleStation": {
+      "type": "text",
+      "value": "T,Numpad4",
+      "title": "Телепорт к станции Белой дыры"
+    },
+    "Teleport To Stranger": {
+      "type": "text",
+      "value": "T,Numpad5",
+      "title": "Телепорт к Страннику"
+    },
+    "Teleport To DreamWorld": {
+      "type": "text",
+      "value": "T,Numpad6",
+      "title": "Телепорт в Мир снов"
+    },
+    "Teleport To QuantumMoon": {
+      "type": "text",
+      "value": "T,Numpad7",
+      "title": "Телепорт к Квантовой луне"
+    },
+    "Teleport To Ship": {
+      "type": "text",
+      "value": "T,Numpad9",
+      "title": "Телепорт к кораблю"
+    },
+    "Teleport Ship To Player": {
+      "type": "text",
+      "value": "T,NumpadDivide",
+      "title": "Телепортировать корабль к игроку"
+    },
+    "Teleport To Probe": {
+      "type": "text",
+      "value": "T,NumpadMultiply",
+      "title": "Телепорт к зонду"
+    },
+    "Teleport To Nomai Probe": {
+      "type": "text",
+      "value": "T,NumpadMinus",
+      "title": "Телепорт к зонду Номаи"
+    },
+    "Teleport To Vessel": {
+      "type": "text",
+      "value": "T,NumpadPlus",
+      "title": "Телепорт к Судну"
+    },
+    "Teleport To Mapping Satellite": {
+      "type": "text",
+      "value": "T,M",
+      "title": "Телепорт к картографическому спутнику"
+    },
+    "Teleport To Backer Satellite": {
+      "type": "text",
+      "value": "T,B",
+      "title": "Телепорт к спутнику спонсоров"
+    },
+    "Give Warp Core Vessel": {
+      "type": "text",
+      "value": "G,T,Digit1",
+      "title": "Выдать варп-ядро: Судно"
+    },
+    "Give Warp Core Broken": {
+      "type": "text",
+      "value": "G,T,Digit2",
+      "title": "Выдать варп-ядро: сломанное"
+    },
+    "Give Warp Core Black": {
+      "type": "text",
+      "value": "G,T,Digit3",
+      "title": "Выдать варп-ядро: чёрное"
+    },
+    "Give Warp Core White": {
+      "type": "text",
+      "value": "G,T,Digit4",
+      "title": "Выдать варп-ядро: белое"
+    },
+    "Give Warp Core None": {
+      "type": "text",
+      "value": "G,T,Digit5",
+      "title": "Убрать варп-ядро"
+    },
+    "Give Lantern Basic": {
+      "type": "text",
+      "value": "G,L,Digit1",
+      "title": "Выдать фонарь: обычный"
+    },
+    "Give Lantern Broken": {
+      "type": "text",
+      "value": "G,L,Digit2",
+      "title": "Выдать фонарь: сломанный"
+    },
+    "Give Lantern Gen1": {
+      "type": "text",
+      "value": "G,L,Digit3",
+      "title": "Выдать фонарь: поколение 1"
+    },
+    "Give Lantern Gen2": {
+      "type": "text",
+      "value": "G,L,Digit4",
+      "title": "Выдать фонарь: поколение 2"
+    },
+    "Give Lantern Gen3": {
+      "type": "text",
+      "value": "G,L,Digit5",
+      "title": "Выдать фонарь: поколение 3"
+    },
+    "Give Vision Torch": {
+      "type": "text",
+      "value": "G,L,Digit6",
+      "title": "Выдать факел видений"
+    },
+    "Give Slide Story 1": {
+      "type": "text",
+      "value": "G,R,S,Digit1",
+      "title": "Выдать сюжетный слайд 1"
+    },
+    "Give Slide Story 2": {
+      "type": "text",
+      "value": "G,R,S,Digit2",
+      "title": "Выдать сюжетный слайд 2"
+    },
+    "Give Slide Story 3": {
+      "type": "text",
+      "value": "G,R,S,Digit3",
+      "title": "Выдать сюжетный слайд 3"
+    },
+    "Give Slide Story 4": {
+      "type": "text",
+      "value": "G,R,S,Digit4",
+      "title": "Выдать сюжетный слайд 4"
+    },
+    "Give Slide Story 5": {
+      "type": "text",
+      "value": "G,R,S,Digit5",
+      "title": "Выдать сюжетный слайд 5"
+    },
+    "Give Slide Burning": {
+      "type": "text",
+      "value": "G,R,S,Digit6",
+      "title": "Выдать слайд «Пламя»"
+    },
+    "Give Slide Experiment": {
+      "type": "text",
+      "value": "G,R,S,Digit7",
+      "title": "Выдать слайд «Эксперимент»"
+    },
+    "Give Slide DamageReport": {
+      "type": "text",
+      "value": "G,R,S,Digit8",
+      "title": "Выдать слайд «Отчёт о повреждениях»"
+    },
+    "Give Slide LanternSecret": {
+      "type": "text",
+      "value": "G,R,S,Digit9",
+      "title": "Выдать слайд «Тайна фонаря»"
+    },
+    "Give Slide Prisoner": {
+      "type": "text",
+      "value": "G,R,S,Numpad0",
+      "title": "Выдать слайд «Заключённый»"
+    },
+    "Give Slide PrisonerFarewell": {
+      "type": "text",
+      "value": "G,R,S,Numpad1",
+      "title": "Выдать слайд «Прощание заключённого»"
+    },
+    "Give Slide Tower": {
+      "type": "text",
+      "value": "G,R,S,Numpad2",
+      "title": "Выдать слайд «Башня»"
+    },
+    "Give Slide SignalJammer": {
+      "type": "text",
+      "value": "G,R,S,Numpad3",
+      "title": "Выдать слайд «Глушитель сигнала»"
+    },
+    "Give Slide Homeworld": {
+      "type": "text",
+      "value": "G,R,S,Numpad4",
+      "title": "Выдать слайд «Родной мир»"
+    },
+    "Give Slide SupernovaEscape": {
+      "type": "text",
+      "value": "G,R,S,Numpad5",
+      "title": "Выдать слайд «Побег от сверхновой»"
+    },
+    "Give Slide Path 1": {
+      "type": "text",
+      "value": "G,R,P,Digit1",
+      "title": "Выдать слайд «Путь 1»"
+    },
+    "Give Slide Path 2": {
+      "type": "text",
+      "value": "G,R,P,Digit2",
+      "title": "Выдать слайд «Путь 2»"
+    },
+    "Give Slide Path 3": {
+      "type": "text",
+      "value": "G,R,P,Digit3",
+      "title": "Выдать слайд «Путь 3»"
+    },
+    "Give Slide Seal 1": {
+      "type": "text",
+      "value": "G,R,P,Digit4",
+      "title": "Выдать слайд «Печать 1»"
+    },
+    "Give Slide Seal 2": {
+      "type": "text",
+      "value": "G,R,P,Digit5",
+      "title": "Выдать слайд «Печать 2»"
+    },
+    "Give Slide Seal 3": {
+      "type": "text",
+      "value": "G,R,P,Digit6",
+      "title": "Выдать слайд «Печать 3»"
+    },
+    "Give Slide Rule 1": {
+      "type": "text",
+      "value": "G,R,P,Digit7",
+      "title": "Выдать слайд «Правило 1»"
+    },
+    "Give Slide Rule 2": {
+      "type": "text",
+      "value": "G,R,P,Digit8",
+      "title": "Выдать слайд «Правило 2»"
+    },
+    "Give Slide Rule 3": {
+      "type": "text",
+      "value": "G,R,P,Digit9",
+      "title": "Выдать слайд «Правило 3»"
+    },
+    "Give Slide Rule 4": {
+      "type": "text",
+      "value": "G,R,P,Digit0",
+      "title": "Выдать слайд «Правило 4»"
+    },
+    "Give Identify Conversation Stone": {
+      "type": "text",
+      "value": "C,Digit2",
+      "title": "Выдать камень беседы «Опознать»"
+    },
+    "Give Explain Conversation Stone": {
+      "type": "text",
+      "value": "C,Digit3",
+      "title": "Выдать камень беседы «Объяснить»"
+    },
+    "Give Eye Conversation Stone": {
+      "type": "text",
+      "value": "C,Digit4",
+      "title": "Выдать камень беседы «Око»"
+    },
+    "Give Quantum Moon Conversation Stone": {
+      "type": "text",
+      "value": "C,Digit5",
+      "title": "Выдать камень беседы «Квантовая луна»"
+    },
+    "Give You Conversation Stone": {
+      "type": "text",
+      "value": "C,Digit6",
+      "title": "Выдать камень беседы «Ты»"
+    },
+    "Give Me Conversation Stone": {
+      "type": "text",
+      "value": "C,Digit7",
+      "title": "Выдать камень беседы «Я»"
+    },
+    "Give Nomai Conversation Stone": {
+      "type": "text",
+      "value": "C,Digit8",
+      "title": "Выдать камень беседы «Номаи»"
+    },
+    "Give Sun Station Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit1",
+      "title": "Выдать проекционный камень «Солнечная станция»"
+    },
+    "Give Time Loop Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit2",
+      "title": "Выдать проекционный камень «Петля времени»"
+    },
+    "Give Eye Locator Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit3",
+      "title": "Выдать проекционный камень «Локатор Ока»"
+    },
+    "Give Mine Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit4",
+      "title": "Выдать проекционный камень «Шахта»"
+    },
+    "Give Observatory Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit5",
+      "title": "Выдать проекционный камень «Обсерватория»"
+    },
+    "Give Gravity Cannon Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit6",
+      "title": "Выдать проекционный камень «Гравитационная пушка»"
+    },
+    "Give Quantum Fragment Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit7",
+      "title": "Выдать проекционный камень «Квантовый фрагмент»"
+    },
+    "Give Black Hole Forge Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit8",
+      "title": "Выдать проекционный камень «Кузница чёрной дыры»"
+    },
+    "Give Construction Yard 1st Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit9",
+      "title": "Выдать проекционный камень «Строительная площадка 1»"
+    },
+    "Give Construction Yard 2nd Projection Stone": {
+      "type": "text",
+      "value": "P,S,Digit0",
+      "title": "Выдать проекционный камень «Строительная площадка 2»"
+    },
+    "Give Statue Projection Stone": {
+      "type": "text",
+      "value": "P,S,Numpad1",
+      "title": "Выдать проекционный камень «Статуя»"
+    },
+    "Give Tracking Module Projection Stone": {
+      "type": "text",
+      "value": "P,S,Numpad2",
+      "title": "Выдать проекционный камень «Отслеживающий модуль»"
+    },
+    "Give Launch Module Projection Stone": {
+      "type": "text",
+      "value": "P,S,Numpad3",
+      "title": "Выдать проекционный камень «Пусковой модуль»"
+    },
+    "Give Control Module Projection Stone": {
+      "type": "text",
+      "value": "P,S,Numpad4",
+      "title": "Выдать проекционный камень «Управляющий модуль»"
+    },
+    "Give Volcanic Projection Stone": {
+      "type": "text",
+      "value": "P,S,Numpad5",
+      "title": "Выдать проекционный камень «Вулканический»"
+    },
+    "Give High Energy Lab Projection Stone": {
+      "type": "text",
+      "value": "P,S,Numpad6",
+      "title": "Выдать проекционный камень «Лаборатория высокой энергии»"
+    },
+    "Give North Pole Projection Stone": {
+      "type": "text",
+      "value": "P,S,Numpad7",
+      "title": "Выдать проекционный камень «Северный полюс»"
+    },
+    "Eject Ship": {
+      "type": "text",
+      "value": "LeftAlt,Digit1",
+      "title": "Катапультировать корабль"
+    },
+    "Explode Ship": {
+      "type": "text",
+      "value": "LeftAlt,Digit2",
+      "title": "Взорвать корабль"
+    }
   }
 }

--- a/OWML_fonts_patch/Mods/clubby789.OWClock/Fonts/README.md
+++ b/OWML_fonts_patch/Mods/clubby789.OWClock/Fonts/README.md
@@ -1,0 +1,3 @@
+# Clock mod fonts
+
+This folder will be filled by `scripts/install_fonts.py`, which fetches `NotoSans-Regular.ttf` during installation. Keeping the font out of the repository allows the mod to retain Cyrillic coverage while avoiding bulky binaries in version control.

--- a/OWML_fonts_patch/Mods/clubby789.OWClock/config.json
+++ b/OWML_fonts_patch/Mods/clubby789.OWClock/config.json
@@ -1,58 +1,80 @@
 {
   "enabled": true,
   "settings": {
-    "Count Up": true,
-    "Count In Milliseconds": false,
-    "Events to Display": 5,
-    "Only Display When Suit Equipped": false,
-    "HudScale": {
-      "max": 80,
-      "min": 10,
-      "type": "slider",
-      "value": 38.0,
-      "title": "Event List Width"
-    },
-    "Sun": {
-      "no": "No",
+    "Count Up": {
       "type": "toggle",
       "value": true,
-      "yes": "Yes",
-      "title": "Show Sun Events"
+      "title": "Отсчёт вперёд",
+      "yes": "Да",
+      "no": "Нет"
     },
-    "TimeLoop": {
-      "no": "No",
-      "type": "toggle",
-      "value": true,
-      "yes": "Yes",
-      "title": "Show Timeloop Events"
-    },
-    "WarpPlatforms": {
-      "no": "No",
-      "type": "toggle",
-      "value": true,
-      "yes": "Yes",
-      "title": "Show Warp Platform Events"
-    },
-    "Chert": {
-      "no": "No",
-      "type": "toggle",
-      "value": true,
-      "yes": "Yes",
-      "title": "Show Chert's Mood"
-    },
-    "Misc": {
-      "no": "No",
-      "type": "toggle",
-      "value": true,
-      "yes": "Yes",
-      "title": "Show Other Events"
-    },
-    "EotE": {
-      "no": "No",
+    "Count In Milliseconds": {
       "type": "toggle",
       "value": false,
-      "yes": "Yes",
-      "title": "Show Echoes of the Eye Events"
+      "title": "Показывать миллисекунды",
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "Events to Display": {
+      "type": "number",
+      "value": 5,
+      "title": "Количество отображаемых событий"
+    },
+    "Only Display When Suit Equipped": {
+      "type": "toggle",
+      "value": false,
+      "title": "Показывать только в скафандре",
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "HudScale": {
+      "title": "Ширина списка событий",
+      "type": "slider",
+      "value": 38.0,
+      "min": 10,
+      "max": 80
+    },
+    "Sun": {
+      "title": "Показывать события Солнца",
+      "type": "toggle",
+      "value": true,
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "TimeLoop": {
+      "title": "Показывать события петли времени",
+      "type": "toggle",
+      "value": true,
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "WarpPlatforms": {
+      "title": "Показывать события варп-платформ",
+      "type": "toggle",
+      "value": true,
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "Chert": {
+      "title": "Показывать настроение Чёрта",
+      "type": "toggle",
+      "value": true,
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "Misc": {
+      "title": "Показывать прочие события",
+      "type": "toggle",
+      "value": true,
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "EotE": {
+      "title": "Показывать события «Эха Ока»",
+      "type": "toggle",
+      "value": false,
+      "yes": "Да",
+      "no": "Нет"
     }
   }
 }

--- a/OWML_fonts_patch/Mods/clubby789.OWClock/default-config.json
+++ b/OWML_fonts_patch/Mods/clubby789.OWClock/default-config.json
@@ -1,59 +1,81 @@
 {
-	"$schema": "https://raw.githubusercontent.com/ow-mods/owml/master/schemas/config_schema.json",
-	"enabled": true,
-	"settings": {
-		"Count Up": true,
-		"Count In Milliseconds": false,
-		"Events to Display": 5,
-		"Only Display When Suit Equipped": false,
-		"HudScale": {
-			"title": "Event List Width",
-			"type": "slider",
-			"value": 20,
-			"min": 10,
-			"max": 80
-		},
-		"Sun": {
-			"title": "Show Sun Events",
-			"type": "toggle",
-			"value": true,
-			"yes": "Yes",
-			"no": "No"
-		},
-		"TimeLoop": {
-			"title": "Show Timeloop Events",
-			"type": "toggle",
-			"value": true,
-			"yes": "Yes",
-			"no": "No"
-		},
-		"WarpPlatforms": {
-			"title": "Show Warp Platform Events",
-			"type": "toggle",
-			"value": true,
-			"yes": "Yes",
-			"no": "No"
-		},
-		"Chert": {
-			"title": "Show Chert's Mood",
-			"type": "toggle",
-			"value": true,
-			"yes": "Yes",
-			"no": "No"
-		},
-		"Misc": {
-			"title": "Show Other Events",
-			"type": "toggle",
-			"value": true,
-			"yes": "Yes",
-			"no": "No"
-		},
-		"EotE": {
-			"title": "Show Echoes of the Eye Events",
-			"type": "toggle",
-			"value": true,
-			"yes": "Yes",
-			"no": "No"
-		}
-	}
+  "$schema": "https://raw.githubusercontent.com/ow-mods/owml/master/schemas/config_schema.json",
+  "enabled": true,
+  "settings": {
+    "Count Up": {
+      "type": "toggle",
+      "value": true,
+      "title": "Отсчёт вперёд",
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "Count In Milliseconds": {
+      "type": "toggle",
+      "value": false,
+      "title": "Показывать миллисекунды",
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "Events to Display": {
+      "type": "number",
+      "value": 5,
+      "title": "Количество отображаемых событий"
+    },
+    "Only Display When Suit Equipped": {
+      "type": "toggle",
+      "value": false,
+      "title": "Показывать только в скафандре",
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "HudScale": {
+      "title": "Ширина списка событий",
+      "type": "slider",
+      "value": 20,
+      "min": 10,
+      "max": 80
+    },
+    "Sun": {
+      "title": "Показывать события Солнца",
+      "type": "toggle",
+      "value": true,
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "TimeLoop": {
+      "title": "Показывать события петли времени",
+      "type": "toggle",
+      "value": true,
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "WarpPlatforms": {
+      "title": "Показывать события варп-платформ",
+      "type": "toggle",
+      "value": true,
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "Chert": {
+      "title": "Показывать настроение Чёрта",
+      "type": "toggle",
+      "value": true,
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "Misc": {
+      "title": "Показывать прочие события",
+      "type": "toggle",
+      "value": true,
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "EotE": {
+      "title": "Показывать события «Эха Ока»",
+      "type": "toggle",
+      "value": true,
+      "yes": "Да",
+      "no": "Нет"
+    }
+  }
 }

--- a/OWML_fonts_patch/Mods/clubby789.OWClock/events.json
+++ b/OWML_fonts_patch/Mods/clubby789.OWClock/events.json
@@ -1,154 +1,154 @@
 {
-	"eventList": [
-		{
-			"Timestamp": 0.0,
-			"Name": "Loop Begins",
-			"type": 1
-		},
-		{
-			"Timestamp": 120.0,
-			"Name": "Hourglass Sand Begins to Flow",
-			"type": 4
-		},
-		{
-			"Timestamp": 201.0,
-			"Name": "Satellite reaches 40 degrees",
-			"type": 5
-		},
-		{
-			"Timestamp": 400.0,
-			"Name": "The Stranger solar sails deploy",
-			"type": 5
-		},
-		{
-			"Timestamp": 430.0,
-			"Name": "Sun Station Warp",
-			"type": 2
-		},
-		{
-			"Timestamp": 470.0,
-			"Name": "Ash Twin Warp",
-			"type": 2
-		},
-		{
-			"Timestamp": 480.0,
-			"Name": "Sun Station Warp",
-			"type": 2
-		},
-		{
-			"Timestamp": 530.0,
-			"Name": "Sun Station Warp",
-			"type": 2
-		},
-		{
-			"Timestamp": 580.0,
-			"Name": "Sun Station Warp",
-			"type": 2
-		},
-		{
-			"Timestamp": 620.0,
-			"Name": "Ash Twin Warp",
-			"type": 2
-		},
-		{
-			"Timestamp": 630.0,
-			"Name": "Sun Station Warp",
-			"type": 2
-		},
-		{
-			"Timestamp": 660.0,
-			"Name": "Chert Becomes Nervous",
-			"type": 3
-		},
-		{
-			"Timestamp": 680.0,
-			"Name": "Sun Station Warp",
-			"type": 2
-		},
-		{
-			"Timestamp": 690.0,
-			"Name": "Sun Station Falls",
-			"type": 0
-		},
-		{
-			"Timestamp": 765.0,
-			"Name": "Ash Twin Warp",
-			"type": 2
-		},
-		{
-			"Timestamp": 780.0,
-			"Name": "Dam bursts",
-			"type": 5
-		},
-		{
-			"Timestamp": 790.0,
-			"Name": "River Lowlands is flooded",
-			"type": 5
-		},
-		{
-			"Timestamp": 810.0,
-			"Name": "Cinder Isles is flooded",
-			"type": 5
-		},
-		{
-			"Timestamp": 820.0,
-			"Name": "Hidden Gorge walkways are destroyed",
-			"type": 5
-		},
-		{
-			"Timestamp": 910.0,
-			"Name": "Ash Twin Warp",
-			"type": 2
-		},
-		{
-			"Timestamp": 1020.0,
-			"Name": "Chert Panics",
-			"type": 3
-		},
-		{
-			"Timestamp": 1050.0,
-			"Name": "Ash Twin Warp",
-			"type": 2
-		},
-		{
-			"Timestamp": 1200.0,
-			"Name": "Ash Twin Warp",
-			"type": 2
-		},
-		{
-			"Timestamp": 1220.0,
-			"Name": "Sand Stops Flowing",
-			"type": 4
-		},
-		{
-			"Timestamp": 1230.0,
-			"Name": "Cinder Isles tower completely falls",
-			"type": 5
-		},
-		{
-			"Timestamp": 1230.0,
-			"Name": "Chert Becomes Catatonic",
-			"type": 3
-		},
-		{
-			"Timestamp": 1235.0,
-			"Name": "Beginning of the End",
-			"type": 1
-		},
-		{
-			"Timestamp": 1290.0,
-			"Name": "Warp Platforms Inactive",
-			"type": 2
-		},
-		{
-			"Timestamp": 1320.0,
-			"Name": "Supernova",
-			"type": 0
-		},
-		{
-			"Timestamp": 1360.0,
-			"Name": "Loop Ends",
-			"type": 1
-		}
-	]
+  "eventList": [
+    {
+      "Timestamp": 0.0,
+      "Name": "Петля начинается",
+      "type": 1
+    },
+    {
+      "Timestamp": 120.0,
+      "Name": "Песок Песочных близнецов начинает течь",
+      "type": 4
+    },
+    {
+      "Timestamp": 201.0,
+      "Name": "Спутник достигает 40 градусов",
+      "type": 5
+    },
+    {
+      "Timestamp": 400.0,
+      "Name": "Солнечные паруса Странника раскрываются",
+      "type": 5
+    },
+    {
+      "Timestamp": 430.0,
+      "Name": "Варп на Солнечную станцию",
+      "type": 2
+    },
+    {
+      "Timestamp": 470.0,
+      "Name": "Варп на Пепельный близнец",
+      "type": 2
+    },
+    {
+      "Timestamp": 480.0,
+      "Name": "Варп на Солнечную станцию",
+      "type": 2
+    },
+    {
+      "Timestamp": 530.0,
+      "Name": "Варп на Солнечную станцию",
+      "type": 2
+    },
+    {
+      "Timestamp": 580.0,
+      "Name": "Варп на Солнечную станцию",
+      "type": 2
+    },
+    {
+      "Timestamp": 620.0,
+      "Name": "Варп на Пепельный близнец",
+      "type": 2
+    },
+    {
+      "Timestamp": 630.0,
+      "Name": "Варп на Солнечную станцию",
+      "type": 2
+    },
+    {
+      "Timestamp": 660.0,
+      "Name": "Чёрт начинает нервничать",
+      "type": 3
+    },
+    {
+      "Timestamp": 680.0,
+      "Name": "Варп на Солнечную станцию",
+      "type": 2
+    },
+    {
+      "Timestamp": 690.0,
+      "Name": "Солнечная станция падает",
+      "type": 0
+    },
+    {
+      "Timestamp": 765.0,
+      "Name": "Варп на Пепельный близнец",
+      "type": 2
+    },
+    {
+      "Timestamp": 780.0,
+      "Name": "Плотина прорывается",
+      "type": 5
+    },
+    {
+      "Timestamp": 790.0,
+      "Name": "Нижние поймы затоплены",
+      "type": 5
+    },
+    {
+      "Timestamp": 810.0,
+      "Name": "Пепельные острова затоплены",
+      "type": 5
+    },
+    {
+      "Timestamp": 820.0,
+      "Name": "Мостки Тайного ущелья разрушены",
+      "type": 5
+    },
+    {
+      "Timestamp": 910.0,
+      "Name": "Варп на Пепельный близнец",
+      "type": 2
+    },
+    {
+      "Timestamp": 1020.0,
+      "Name": "Чёрт паникует",
+      "type": 3
+    },
+    {
+      "Timestamp": 1050.0,
+      "Name": "Варп на Пепельный близнец",
+      "type": 2
+    },
+    {
+      "Timestamp": 1200.0,
+      "Name": "Варп на Пепельный близнец",
+      "type": 2
+    },
+    {
+      "Timestamp": 1220.0,
+      "Name": "Песок перестаёт течь",
+      "type": 4
+    },
+    {
+      "Timestamp": 1230.0,
+      "Name": "Башня на Пепельных островах полностью рушится",
+      "type": 5
+    },
+    {
+      "Timestamp": 1230.0,
+      "Name": "Чёрт впадает в ступор",
+      "type": 3
+    },
+    {
+      "Timestamp": 1235.0,
+      "Name": "Начало конца",
+      "type": 1
+    },
+    {
+      "Timestamp": 1290.0,
+      "Name": "Варп-платформы отключаются",
+      "type": 2
+    },
+    {
+      "Timestamp": 1320.0,
+      "Name": "Сверхновая",
+      "type": 0
+    },
+    {
+      "Timestamp": 1360.0,
+      "Name": "Петля заканчивается",
+      "type": 1
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# OWML Cyrillic font helper
+
+The mods bundled in `OWML_fonts_patch` rely on [Noto Sans Regular](https://fonts.google.com/specimen/Noto+Sans) so that the
+configuration menus and overlays can display Cyrillic characters.  The upstream font is more than half a megabyte, so it is kept
+out of version control to keep pull requests reviewable.  Instead, run the helper below whenever you clone or update the patch.
+
+```bash
+python scripts/install_fonts.py
+```
+
+The script downloads the official font file from the Google Fonts repository, verifies its SHA-256 hash, and copies it into every
+location the packaged mods expect (`OWML_fonts_patch/Fonts/` and each mod's `Fonts/` folder).  Rerun it with `--force` if you ever
+need to refresh the files, or with `--dry-run` to preview the affected paths.
+
+After downloading the font you can optionally run the quick check in `tests/test_fonts.py` to make sure the Cyrillic glyphs that
+the mods depend on are present:
+
+```bash
+python scripts/install_fonts.py  # populate font files
+pip install --user fonttools      # one-time dependency for the verification script
+python -m tests.test_fonts
+```
+
+The helper downloads the font under its original SIL Open Font License; no local modifications are made.

--- a/scripts/install_fonts.py
+++ b/scripts/install_fonts.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Utility for fetching the Cyrillic-capable font used by bundled mods.
+
+The repository intentionally excludes the Noto Sans Regular TTF binary so that
+pull requests stay lightweight.  This helper downloads the upstream font and
+copies it into every location expected by OWML and the packaged mods.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import sys
+import urllib.error
+import urllib.request
+from typing import Iterable
+
+FONT_URL = (
+    "https://github.com/googlefonts/noto-fonts/raw/main/hinted/ttf/NotoSans/"
+    "NotoSans-Regular.ttf"
+)
+FONT_SHA256 = "b85c38ecea8a7cfb39c24e395a4007474fa5a4fc864f6ee33309eb4948d232d5"
+FONT_FILENAME = "NotoSans-Regular.ttf"
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FONT_TARGETS = [
+    REPO_ROOT / "OWML_fonts_patch" / "Fonts" / FONT_FILENAME,
+    REPO_ROOT
+    / "OWML_fonts_patch"
+    / "Mods"
+    / "PacificEngine.CheatsMod"
+    / "Fonts"
+    / FONT_FILENAME,
+    REPO_ROOT
+    / "OWML_fonts_patch"
+    / "Mods"
+    / "clubby789.OWClock"
+    / "Fonts"
+    / FONT_FILENAME,
+]
+
+
+def sha256_digest(data: bytes) -> str:
+    """Return the hex encoded SHA-256 digest of ``data``."""
+
+    return hashlib.sha256(data).hexdigest()
+
+
+def existing_font_bytes() -> bytes | None:
+    """Return cached font bytes if a valid copy already exists on disk."""
+
+    for target in FONT_TARGETS:
+        if not target.exists():
+            continue
+        try:
+            data = target.read_bytes()
+        except OSError as exc:  # pragma: no cover - defensive
+            print(f"Warning: could not read {target}: {exc}", file=sys.stderr)
+            continue
+        digest = sha256_digest(data)
+        if digest == FONT_SHA256:
+            return data
+        print(
+            f"Existing font at {target} has unexpected hash ({digest}); replacing.",
+            file=sys.stderr,
+        )
+    return None
+
+
+def download_font() -> bytes:
+    """Download the upstream font and validate its checksum."""
+
+    request = urllib.request.Request(
+        FONT_URL, headers={"User-Agent": "OWML-font-fetcher/1.0"}
+    )
+    try:
+        with urllib.request.urlopen(request) as response:
+            payload = response.read()
+    except urllib.error.URLError as exc:  # pragma: no cover - network failure
+        raise RuntimeError(f"Failed to download {FONT_URL}: {exc}") from exc
+
+    digest = sha256_digest(payload)
+    if digest != FONT_SHA256:
+        raise RuntimeError(
+            "Downloaded font does not match expected SHA-256. "
+            f"Expected {FONT_SHA256}, got {digest}."
+        )
+    return payload
+
+
+def ensure_targets(font_bytes: bytes, force: bool = False, dry_run: bool = False) -> None:
+    """Copy ``font_bytes`` into each required location."""
+
+    for target in FONT_TARGETS:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists() and not force:
+            try:
+                existing = target.read_bytes()
+            except OSError as exc:  # pragma: no cover - defensive
+                print(f"Warning: could not read {target}: {exc}", file=sys.stderr)
+            else:
+                if sha256_digest(existing) == FONT_SHA256:
+                    print(f"{target}: up to date")
+                    continue
+                print(f"{target}: checksum mismatch, refreshing")
+        if dry_run:
+            print(f"Would write font to {target}")
+            continue
+        tmp_path = target.with_suffix(target.suffix + ".tmp")
+        with tmp_path.open("wb") as handle:
+            handle.write(font_bytes)
+        os.replace(tmp_path, target)
+        print(f"Wrote {target}")
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite existing fonts even if the checksum already matches",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="display actions without writing any files",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    font_bytes = None if args.force else existing_font_bytes()
+    if font_bytes is None:
+        font_bytes = download_font()
+    ensure_targets(font_bytes, force=args.force, dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -32,7 +32,11 @@ def load_required_characters() -> set[str]:
     """Collect the Cyrillic characters present in the mod configuration."""
 
     cheats_config = REPO_ROOT / "OWML_fonts_patch/Mods/PacificEngine.CheatsMod/config.json"
+    clock_config = REPO_ROOT / "OWML_fonts_patch/Mods/clubby789.OWClock/config.json"
+    clock_events = REPO_ROOT / "OWML_fonts_patch/Mods/clubby789.OWClock/events.json"
+
     texts: list[str] = []
+
     with cheats_config.open(encoding="utf-8") as handle:
         config = json.load(handle)
     for section in config.get("settings", {}).values():
@@ -42,6 +46,23 @@ def load_required_characters() -> set[str]:
             )
         elif isinstance(section, str):
             texts.append(section)
+
+    with clock_config.open(encoding="utf-8") as handle:
+        config = json.load(handle)
+    for section in config.get("settings", {}).values():
+        if isinstance(section, dict):
+            texts.extend(
+                value for key, value in section.items() if isinstance(value, str)
+            )
+        elif isinstance(section, str):
+            texts.append(section)
+
+    with clock_events.open(encoding="utf-8") as handle:
+        events = json.load(handle)
+    for entry in events.get("eventList", []):
+        name = entry.get("Name")
+        if isinstance(name, str):
+            texts.append(name)
     texts.append(
         "АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ"
         "абвгдеёжзийклмнопрстуфхцчшщъыьэюя"

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -1,0 +1,81 @@
+"""Sanity checks that the downloaded fonts cover the mod's Cyrillic text."""
+
+from __future__ import annotations
+
+import json
+import unicodedata
+from pathlib import Path
+from typing import Iterable
+
+try:
+    from fontTools.ttLib import TTFont
+except ImportError as exc:  # pragma: no cover - dependency guard
+    raise SystemExit(
+        "fontTools is required for this check. Install it with `pip install fonttools`."
+    ) from exc
+
+from scripts import install_fonts
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _iter_cyrillic_characters(strings: Iterable[str]) -> set[str]:
+    characters: set[str] = set()
+    for text in strings:
+        for char in text:
+            if "CYRILLIC" in unicodedata.name(char, ""):
+                characters.add(char)
+    return characters
+
+
+def load_required_characters() -> set[str]:
+    """Collect the Cyrillic characters present in the mod configuration."""
+
+    cheats_config = REPO_ROOT / "OWML_fonts_patch/Mods/PacificEngine.CheatsMod/config.json"
+    texts: list[str] = []
+    with cheats_config.open(encoding="utf-8") as handle:
+        config = json.load(handle)
+    for section in config.get("settings", {}).values():
+        if isinstance(section, dict):
+            texts.extend(
+                value for key, value in section.items() if isinstance(value, str)
+            )
+        elif isinstance(section, str):
+            texts.append(section)
+    texts.append(
+        "АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ"
+        "абвгдеёжзийклмнопрстуфхцчшщъыьэюя"
+    )
+    return _iter_cyrillic_characters(texts)
+
+
+def verify_font_contains(font_path: Path, required_chars: set[str]) -> None:
+    """Assert that ``font_path`` includes glyphs for ``required_chars``."""
+
+    font = TTFont(str(font_path))
+    try:
+        cmap = font.getBestCmap() or {}
+    finally:
+        font.close()
+    missing = [char for char in sorted(required_chars) if ord(char) not in cmap]
+    assert not missing, f"{font_path} is missing glyphs for: {''.join(missing)}"
+
+
+def main() -> None:
+    install_fonts.main([])
+    required = load_required_characters()
+    assert required, "Did not detect any Cyrillic characters to verify."
+
+    for target in install_fonts.FONT_TARGETS:
+        assert target.exists(), f"Expected font at {target}"
+        digest = install_fonts.sha256_digest(target.read_bytes())
+        assert (
+            digest == install_fonts.FONT_SHA256
+        ), f"Unexpected font hash at {target}: {digest}"
+        verify_font_contains(target, required)
+
+    print("All fonts include the required Cyrillic glyphs.")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI usage
+    main()


### PR DESCRIPTION
## Summary
- ignore committed TTF payloads and document how to populate the Fonts folders
- add a Python helper that downloads/validates Noto Sans and copies it into each mod
- provide a README and verification script to ensure Cyrillic glyphs remain available

## Testing
- python scripts/install_fonts.py
- python -m tests.test_fonts

------
https://chatgpt.com/codex/tasks/task_e_68cfd6c69e3c83218d22768bf14be822